### PR TITLE
chore: add commit-msg hook to enforce commit message format

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+commit_msg_file=$1
+commit_msg=$(cat $commit_msg_file)
+
+# 허용되는 커밋 메시지 접두사 목록
+prefixes="chore:|docs:|feat:|fix:|refactor:|delete:|typo:|add:"
+
+# 정규식으로 커밋 메시지 형식 검사
+if ! echo "$commit_msg" | grep -qE "^($prefixes)[[:space:]]"; then
+  echo ""
+  echo "❌ 커밋 메시지 형식 오류!"
+  echo "🔷 형식: [type]: [subject]"
+  echo "💡 예시: feat: 로그인 기능 추가"
+  echo ""
+  echo "커밋 메시지는 아래 접두사 중 하나로 시작해야 합니다:"
+  echo ""
+  echo "  - add      : 코드/파일/리소스 추가"
+  echo "  - chore    : 빌드, 설정, 도구 변경"
+  echo "  - delete   : 기존 기능 또는 파일 제거"
+  echo "  - docs     : 문서 수정"
+  echo "  - feat     : 새로운 기능 추가"
+  echo "  - fix      : 버그 수정"
+  echo "  - refactor : 기능 변경 없는 코드 리팩토링"
+  echo "  - typo     : 오타, 주석, 텍스트 수정"
+  echo ""
+  exit 1
+fi


### PR DESCRIPTION
### 변경 사항
- Husky commit-msg 훅 추가
- 커밋 메시지 규칙 검사 및 위반 시 커밋 차단
- Conventional Commits 형식(feat, fix, chore 등) 강제

### 목적
- 팀 커밋 메시지 일관성 유지
- 잘못된 커밋 메시지로 인한 혼동 방지