### PR TITLE
chore: add path aliases in vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,10 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),
+      '@app': resolve(__dirname, './src/_app'),
+      '@pages': resolve(__dirname, './src/_pages'),
+      '@domain': resolve(__dirname, './src/domain'),
+      '@shared': resolve(__dirname, './src/shared'),
     },
   },
 });


### PR DESCRIPTION
### 변경 내용
- Vite 설정(vite.config.ts)에 경로 별칭(alias) 추가
  - '@app' → './src/_app'
  - '@pages' → './src/_pages'
  - '@domain' → './src/domain'
  - '@shared' → './src/shared'